### PR TITLE
Restrict pip Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends  nano wget git curl less psmisc && \
     apt-get install -y --no-install-recommends python3.5 python3-pip python3-setuptools && \
-    pip3 install --upgrade pip
+    pip3 install --no-cache-dir --upgrade pip==20.3.4 && \
+    apt-get clean
 
 ADD . /MULDER
 
-RUN cd /MULDER && pip3 install -r requirements.txt && \
+RUN cd /MULDER && pip3 install --no-cache-dir -r requirements.txt && \
     python3.5 setup.py install
 
 


### PR DESCRIPTION
MULDER uses Python 3.5 and pip 21.0  has dropped support for Python 3.5 in January 2021.
So I updated the Dockerfile to restrict pip to version 20.3.4.

This update is necessary to build a new Docker image of MULDER.